### PR TITLE
Add command_wrapper support to sysconfig-based OSes

### DIFF
--- a/templates/radio.sysconfig.erb
+++ b/templates/radio.sysconfig.erb
@@ -8,3 +8,7 @@ GRAYLOG2_RADIO_JAVA_OPTS="<%= @java_opts %>"
 
 # Pass some extra args to graylog2-radio. (i.e. "-d" to enable debug mode)
 GRAYLOG2_RADIO_ARGS="<%= @extra_args %>"
+
+# Program that will be used to wrap the graylog2-server command. Useful to
+# support programs like authbind.
+GRAYLOG2_COMMAND_WRAPPER="<%= @command_wrapper %>"

--- a/templates/server.sysconfig.erb
+++ b/templates/server.sysconfig.erb
@@ -8,3 +8,7 @@ GRAYLOG2_SERVER_JAVA_OPTS="<%= @java_opts %>"
 
 # Pass some extra args to graylog2-server. (i.e. "-d" to enable debug mode)
 GRAYLOG2_SERVER_ARGS="<%= @extra_args %>"
+
+# Program that will be used to wrap the graylog2-server command. Useful to
+# support programs like authbind.
+GRAYLOG2_COMMAND_WRAPPER="<%= @command_wrapper %>"

--- a/templates/web.sysconfig.erb
+++ b/templates/web.sysconfig.erb
@@ -12,3 +12,7 @@ GRAYLOG2_WEB_JAVA_OPTS=""
 
 # Pass some extra args to graylog2-web. (i.e. "-d" to enable debug mode)
 GRAYLOG2_WEB_ARGS=""
+
+# Program that will be used to wrap the graylog2-server command. Useful to
+# support programs like authbind.
+GRAYLOG2_COMMAND_WRAPPER="<%= @command_wrapper %>"


### PR DESCRIPTION
command_wrapper support was added in 13da3e96cc41c6b44a508faed3ed81fd88f049e9 but only for debian-based OSes, this commit also makes it work for redhat-based OSes (I've got a corresponding pull request to the packaging repo at https://github.com/Graylog2/fpm-recipes/pull/23 to make the init scripts understand it)