### PR TITLE
use required_packages instead of require for package apt-transport-https

### DIFF
--- a/manifests/repo/debian.pp
+++ b/manifests/repo/debian.pp
@@ -22,15 +22,13 @@ class graylog2::repo::debian (
 
   if !defined(Apt::Source[$repo_name]) {
     apt::source { $repo_name:
-      location    => $baseurl,
-      release     => $release,
-      repos       => $repos,
-      pin         => $pin,
-      include_src => false,
-      require     => [
-        File['/etc/apt/trusted.gpg.d/graylog2-keyring.gpg'],
-        Package['apt-transport-https'],
-      ],
+      location          => $baseurl,
+      release           => $release,
+      repos             => $repos,
+      pin               => $pin,
+      include_src       => false,
+      required_packages => ['apt-transport-https'],
+      require           => File['/etc/apt/trusted.gpg.d/graylog2-keyring.gpg']
     }
 
     file {'/etc/apt/trusted.gpg.d/graylog2-keyring.gpg':


### PR DESCRIPTION
Using require => Package['apt-transport-https'] may cause dependency cycle when this package is already defined somewhere else. This can be fixed by using the required_packages parameter. 