### PR TITLE
Enable the special-case operation for rest_transport_uri when rest_liste...

### DIFF
--- a/templates/server.conf.erb
+++ b/templates/server.conf.erb
@@ -41,7 +41,11 @@ rest_listen_uri = <%= @rest_listen_uri %>
 # is set to a wildcard IP address (0.0.0.0) the first non-loopback IPv4 system address is used.
 # This will be promoted in the cluster discovery APIs and other nodes may try to connect on this
 # address. (see rest_listen_uri)
+<%- if @rest_listen_uri =~ /0\.0\.0\.0/ -%>
+#rest_transport_uri = <%= @rest_transport_uri %>
+<% else %>
 rest_transport_uri = <%= @rest_transport_uri %>
+<% end %>
 
 # Enable CORS headers for REST API. This is necessary for JS-clients accessing the server directly.
 # If these are disabled, modern browsers will not be able to retrieve resources from the server.


### PR DESCRIPTION
...n_uri = 0.0.0.0

Hullo - I spent ages on this trying to figure out why my three-node cluster in AWS was never able to properly function as a cluster - each node would only ever see itself in System -> Nodes, despite the fact that only one of the three was marked as 'master'.

The existing logic in the `graylog/server/server.conf` does not permit the documented case in the config file where `rest_listen_url` is set to a wildcard IP address for the `rest_transport_uri` to be commented out and automatically inherit the first IP address on the machine.