### PR TITLE
Suppress diffs on config file

### DIFF
--- a/manifests/web/configure.pp
+++ b/manifests/web/configure.pp
@@ -79,11 +79,12 @@ class graylog2::web::configure (
   }
 
   file {$config_file:
-    ensure  => file,
-    owner   => $daemon_username,
-    group   => $daemon_username,
-    mode    => '0640',
-    content => template("${module_name}/web.conf.erb"),
+    ensure    => file,
+    owner     => $daemon_username,
+    group     => $daemon_username,
+    mode      => '0640',
+    show_diff => false,
+    content   => template("${module_name}/web.conf.erb"),
   }
 
 }


### PR DESCRIPTION
Since this file contains secrets, diffs should be suppressed, in case the puppet logs are later world-readable.