### PR TITLE
Quote bare integer to pass validation check.

### DIFF
--- a/manifests/server/params.pp
+++ b/manifests/server/params.pp
@@ -159,7 +159,7 @@ class graylog2::server::params {
   $usage_statistics_enabled = true
   $usage_statistics_gzip_enabled = true
   $usage_statistics_initial_delay = '5m'
-  $usage_statistics_max_queue_size = 10
+  $usage_statistics_max_queue_size = '10'
   $usage_statistics_offline_mode = false
   $usage_statistics_report_interval = '6h'
   $usage_statistics_url = 'https://stats-collector.graylog.com/submit/'


### PR DESCRIPTION
I found one parameter was failing a type check on Puppet 4.1; this PR simply converts the bare integer to a quoted one.