### PR TITLE
Use Apt module for Keys

### DIFF
--- a/manifests/repo/debian.pp
+++ b/manifests/repo/debian.pp
@@ -20,6 +20,13 @@ class graylog2::repo::debian (
     ensure_packages(['apt-transport-https'])
   }
 
+  if !defined(Apt::Key[$repo_name]) {
+    apt::key { $repo_name:
+      key        => '28AB6EB572779C2AD196BE22D44C1D8DB1606F22',
+      key_server => 'hkp://pgp.surfnet.nl:80'
+    }
+  }
+
   if !defined(Apt::Source[$repo_name]) {
     apt::source { $repo_name:
       location    => $baseurl,
@@ -27,18 +34,10 @@ class graylog2::repo::debian (
       repos       => $repos,
       pin         => $pin,
       include_src => false,
-      require     => [ 
-        File['/etc/apt/trusted.gpg.d/graylog2-keyring.gpg'],
+      require     => [
         Package['apt-transport-https'],
-      ]
-    }
-
-    file {'/etc/apt/trusted.gpg.d/graylog2-keyring.gpg':
-      ensure => present,
-      owner  => 'root',
-      group  => 'root',
-      mode   => '0444',
-      source => 'puppet:///modules/graylog2/graylog2-keyring.gpg',
+        Apt::Key[$repo_name],
+      ],
     }
   }
 }

--- a/manifests/repo/debian.pp
+++ b/manifests/repo/debian.pp
@@ -22,13 +22,15 @@ class graylog2::repo::debian (
 
   if !defined(Apt::Source[$repo_name]) {
     apt::source { $repo_name:
-      location          => $baseurl,
-      release           => $release,
-      repos             => $repos,
-      pin               => $pin,
-      include_src       => false,
-      required_packages => ['apt-transport-https'],
-      require           => File['/etc/apt/trusted.gpg.d/graylog2-keyring.gpg']
+      location    => $baseurl,
+      release     => $release,
+      repos       => $repos,
+      pin         => $pin,
+      include_src => false,
+      require     => [ 
+        File['/etc/apt/trusted.gpg.d/graylog2-keyring.gpg'],
+        Package['apt-transport-https'],
+      ]
     }
 
     file {'/etc/apt/trusted.gpg.d/graylog2-keyring.gpg':


### PR DESCRIPTION
This PR replaces the hard-coded PGP key with one pulled dynamically from the `pgp.surfnet.nl` key server. It also removes the `required_packages` parameter from the `apt::source` to avoid an obscure (and somewhat hard to diagnose) error on Puppet 4.1.
