### PR TITLE
Add Gentoo Support

### DIFF
--- a/manifests/dashboard/params.pp
+++ b/manifests/dashboard/params.pp
@@ -12,7 +12,7 @@ class graylog2::dashboard::params {
 
   # OS specific settings.
   case $::osfamily {
-    'Debian', 'RedHat': {
+    'Debian', 'RedHat', 'Gentoo': {
       # Nothing yet.
     }
     default: {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -15,6 +15,7 @@ class graylog2::params {
   $repo_release = $::osfamily ? {
     'Debian' => $::lsbdistcodename,
     'RedHat' => '',
+    'Gentoo' => '',
     default  => fail("${::osfamily} is not supported by ${module_name}")
   }
 
@@ -23,18 +24,21 @@ class graylog2::params {
   $repo_key_source = $::osfamily ? {
       'Debian' => '',
       'Redhat' => 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-graylog2',
+      'Gentoo' => '',
       default => fail("${::osfamily} is not supported by ${module_name}")
   }
 
   $repo_gpgcheck = $::osfamily ? {
       'Debian' => 0,
       'Redhat' => 1,
+      'Gentoo' => 0,
       default => fail("${::osfamily} is not supported by ${module_name}")
   }
 
   $repo_enabled = $::osfamily ? {
       'Debian' => 0,
       'Redhat' => 1,
+      'Gentoo' => 0,
       default => fail("${::osfamily} is not supported by ${module_name}")
   }
 

--- a/manifests/radio/configure.pp
+++ b/manifests/radio/configure.pp
@@ -150,6 +150,19 @@ class graylog2::radio::configure (
         content => $template_content,
         }
       }
+    'Gentoo': {
+      $template_content = $template_file ? {
+        ''      => template("${module_name}/radio.gentoo.default.erb"),
+        default => template("${module_name}/${template_file}"),
+      }
+      file { '/etc/conf.d/graylog-radio':
+        ensure  => present,
+        owner   => 'root',
+        group   => 'root',
+        mode    => '0644',
+        content => $template_content,
+        }
+      }
     default: {
       fail("${::osfamily} is not supported by ${module_name}")
     }

--- a/manifests/radio/params.pp
+++ b/manifests/radio/params.pp
@@ -12,7 +12,7 @@ class graylog2::radio::params {
 
   # OS specific settings.
   case $::osfamily {
-    'Debian', 'RedHat': {
+    'Debian', 'RedHat', 'Gentoo': {
       # Nothing yet.
     }
     default: {

--- a/manifests/radio/service.pp
+++ b/manifests/radio/service.pp
@@ -16,6 +16,7 @@ class graylog2::radio::service (
 
   $service_provider = $::operatingsystem ? {
     'Ubuntu' => 'upstart',
+    'Gentoo' => 'openrc',
     default  => undef,
   }
 

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -29,6 +29,7 @@ class graylog2::repo (
     $repo_baseurl = $::osfamily ? {
         'Debian' => 'https://packages.graylog2.org/repo/debian/',
         'RedHat' => "https://packages.graylog2.org/repo/el/\$releasever/${version}/\$basearch/",
+        'Gentoo' => '',
         default  => fail("${::osfamily} is not supported by ${module_name}")
     }
   }
@@ -55,6 +56,8 @@ class graylog2::repo (
         require   => Anchor['graylog2::repo::begin'],
         before    => Anchor['graylog2::repo::end'],
       }
+    }
+    'Gentoo': {
     }
     default: { fail("${::osfamily} is not supported by ${module_name}") }
   }

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -9,11 +9,14 @@
 # Copyright 2014 synyx GmbH & Co. KG
 #
 class graylog2::server (
-  $package_version = $graylog2::server::params::package_version,
-  $service_ensure  = $graylog2::server::params::service_ensure,
-  $service_enable  = $graylog2::server::params::service_enable,
-  $config_file     = $graylog2::server::params::config_file,
-  $daemon_username = $graylog2::server::params::daemon_username,
+  $package_version                                    = $graylog2::server::params::package_version,
+  $service_ensure                                     = $graylog2::server::params::service_ensure,
+  $service_enable                                     = $graylog2::server::params::service_enable,
+  $config_file                                        = $graylog2::server::params::config_file,
+  $daemon_username                                    = $graylog2::server::params::daemon_username,
+  $graylog_home_dir                                   = $graylog2::server::params::graylog_home_dir,
+  $log_file                                           = $graylog2::server::params::log_file,
+  $pid_file                                           = $graylog2::server::params::pid_file,
 
   $alert_check_interval                               = $graylog2::server::params::alert_check_interval,
   $allow_highlighting                                 = $graylog2::server::params::allow_highlighting,
@@ -149,14 +152,17 @@ class graylog2::server (
   $versionchecks_uri                                  = $graylog2::server::params::versionchecks_uri,
 ) inherits graylog2::server::params {
 
-  anchor {'graylog2::server::start': }->
-  class {'graylog2::server::package':
+  anchor { 'graylog2::server::start': }->
+  class { 'graylog2::server::package':
     package => $graylog2::server::params::package_name,
     version => $package_version,
   } ->
-  class {'graylog2::server::configure':
-    config_file     => $config_file,
-    daemon_username => $daemon_username,
+  class { 'graylog2::server::configure':
+    config_file                                        => $config_file,
+    daemon_username                                    => $daemon_username,
+    graylog_home_dir                                   => $graylog_home_dir,
+    log_file                                           => $log_file,
+    pid_file                                           => $pid_file,
 
     alert_check_interval                               => $alert_check_interval,
     allow_highlighting                                 => $allow_highlighting,
@@ -291,11 +297,11 @@ class graylog2::server (
     versionchecks                                      => $versionchecks,
     versionchecks_uri                                  => $versionchecks_uri,
   }~>
-  class {'graylog2::server::service':
+  class { 'graylog2::server::service':
     service_name   => $graylog2::server::params::service_name,
     service_ensure => $service_ensure,
     service_enable => $service_enable,
   } ->
-  anchor {'graylog2::server::end': }
+  anchor { 'graylog2::server::end': }
 
 }

--- a/manifests/server/configure.pp
+++ b/manifests/server/configure.pp
@@ -11,6 +11,9 @@
 class graylog2::server::configure (
   $config_file,
   $daemon_username,
+  $graylog_home_dir,
+  $log_file,
+  $pid_file,
 
   $alert_check_interval,
   $allow_highlighting,
@@ -272,6 +275,9 @@ class graylog2::server::configure (
 
   validate_absolute_path(
     $config_file,
+    $graylog_home_dir,
+    $log_file,
+    $pid_file,
     $message_journal_dir,
     $node_id_file,
     $plugin_dir,
@@ -334,6 +340,15 @@ class graylog2::server::configure (
         group   => 'root',
         mode    => '0644',
         content => template("${module_name}/server.sysconfig.erb"),
+        }
+      }
+    'Gentoo': {
+      file { '/etc/conf.d/graylog-server':
+        ensure  => present,
+        owner   => 'root',
+        group   => 'root',
+        mode    => '0644',
+        content => template("${module_name}/server.gentoo.defaults.erb"),
         }
       }
     default: {

--- a/manifests/server/params.pp
+++ b/manifests/server/params.pp
@@ -12,14 +12,28 @@ class graylog2::server::params {
   # OS specific settings.
   case $::osfamily {
     'Debian', 'RedHat': {
-      # Nothing yet.
+      $package_name = 'graylog-server'
+      $config_file = '/etc/graylog/server/server.conf'
+      $graylog_home_dir = '/var/lib/graylog-server'
+      $plugin_dir = '/usr/share/graylog-server/plugin'
+      $message_journal_dir = '/var/lib/graylog-server/journal'
+      $usage_statistics_dir = '/var/lib/graylog-server/usage-statistics'
+      $java_opts = '-Xms1g -Xmx1g -XX:NewRatio=1 -XX:PermSize=128m -XX:MaxPermSize=256m -server -XX:+ResizeTLAB -XX:+UseConcMarkSweepGC -XX:+CMSConcurrentMTEnabled -XX:+CMSClassUnloadingEnabled -XX:+UseParNewGC -XX:-OmitStackTraceInFastThrow'
+    }
+    'Gentoo': {
+      $package_name = 'app-admin/graylog-server'
+      $config_file = '/etc/graylog/graylog-server.conf'
+      $graylog_home_dir = '/opt/graylog-server'
+      $plugin_dir = '/opt/graylog-server/plugin'
+      $message_journal_dir = '/opt/graylog-server/journal'
+      $usage_statistics_dir = '/opt/graylog-server/usage-statistics'
+      $java_opts = '-Djava.library.path=${GRAYLOG_HOME}/lib/sigar -Xms1g -Xmx1g -XX:NewRatio=1 -XX:PermSize=128m -XX:MaxPermSize=256m -server -XX:+ResizeTLAB -XX:+UseConcMarkSweepGC -XX:+CMSConcurrentMTEnabled -XX:+CMSClassUnloadingEnabled -XX:+UseParNewGC -XX:-OmitStackTraceInFastThrow'
     }
     default: {
       fail("${::osfamily} is not supported by ${module_name}")
     }
   }
 
-  $package_name = 'graylog-server'
   $package_version = 'installed'
 
   $service_name  = 'graylog-server'
@@ -27,8 +41,11 @@ class graylog2::server::params {
   $service_ensure = 'running'
   $service_enable = true
 
-  $config_file = '/etc/graylog/server/server.conf'
+
   $daemon_username = 'graylog'
+
+  $log_file = '/var/log/graylog/graylog-server.log'
+  $pid_file = '/run/graylog/graylog-server.pid'
 
   # Config file variables.
   $alert_check_interval = '60'
@@ -79,10 +96,8 @@ class graylog2::server::params {
   $inputbuffer_ring_size = '65536'
   $inputbuffer_wait_strategy = 'blocking'
   $is_master = true
-  $java_opts = '-Xms1g -Xmx1g -XX:NewRatio=1 -XX:PermSize=128m -XX:MaxPermSize=256m -server -XX:+ResizeTLAB -XX:+UseConcMarkSweepGC -XX:+CMSConcurrentMTEnabled -XX:+CMSClassUnloadingEnabled -XX:+UseParNewGC -XX:-OmitStackTraceInFastThrow'
   $lb_recognition_period_seconds = '3'
   $ldap_connection_timeout = '2000'
-  $message_journal_dir = '/var/lib/graylog-server/journal'
   $message_journal_enabled = true
   $message_journal_flush_age = '1m'
   $message_journal_flush_interval = '1000000'
@@ -112,7 +127,6 @@ class graylog2::server::params {
   $output_flush_interval = '1'
   $output_module_timeout = '10000'
   $password_secret = undef
-  $plugin_dir = '/usr/share/graylog-server/plugin'
   $processbuffer_processors = '5'
   $processor_wait_strategy = 'blocking'
   $rest_enable_cors = false
@@ -153,7 +167,6 @@ class graylog2::server::params {
   $transport_email_web_interface_url = false
   $udp_recvbuffer_sizes = '1048576'
   $usage_statistics_cache_timeout = '15m'
-  $usage_statistics_dir = '/var/lib/graylog-server/usage-statistics'
   $usage_statistics_enabled = true
   $usage_statistics_gzip_enabled = true
   $usage_statistics_initial_delay = '5m'

--- a/manifests/server/service.pp
+++ b/manifests/server/service.pp
@@ -16,6 +16,7 @@ class graylog2::server::service (
 
   $service_provider = $::operatingsystem ? {
     'Ubuntu' => 'upstart',
+    'Gentoo' => 'openrc',
     default  => undef,
   }
 

--- a/manifests/web.pp
+++ b/manifests/web.pp
@@ -25,6 +25,9 @@ class graylog2::web (
   $config_file          = $graylog2::web::params::config_file,
   $daemon_username      = $graylog2::web::params::daemon_username,
   $timeout              = $graylog2::web::params::timeout,
+  $bin_file             = $graylog2::web::params::bin_file,
+  $log_file             = $graylog2::web::params::log_file,
+  $pid_file             = $graylog2::web::params::pid_file,
 
 ) inherits graylog2::web::params {
 
@@ -47,6 +50,9 @@ class graylog2::web (
     config_file          => $config_file,
     daemon_username      => $daemon_username,
     timeout              => $timeout,
+    bin_file             => $bin_file,
+    log_file             => $log_file,
+    pid_file             => $pid_file,
   } ~>
   class {'graylog2::web::service':
     service_name   => $graylog2::web::params::service_name,

--- a/manifests/web/configure.pp
+++ b/manifests/web/configure.pp
@@ -11,6 +11,9 @@
 class graylog2::web::configure (
   $config_file,
   $daemon_username,
+  $bin_file,
+  $log_file,
+  $pid_file,
   $graylog2_server_uris,
   $application_secret,
   $command_wrapper,
@@ -41,6 +44,9 @@ class graylog2::web::configure (
 
   validate_absolute_path(
     $config_file,
+    $bin_file,
+    $log_file,
+    $pid_file,
   )
 
   # This is required and there is no default!
@@ -75,6 +81,15 @@ class graylog2::web::configure (
         group   => 'root',
         mode    => '0644',
         content => template("${module_name}/web.sysconfig.erb"),
+      }
+    }
+    'Gentoo': {
+      file { '/etc/conf.d/graylog-web':
+        ensure  => present,
+        owner   => 'root',
+        group   => 'root',
+        mode    => '0644',
+        content => template("${module_name}/web.gentoo.default.erb"),
       }
     }
     default: {

--- a/manifests/web/params.pp
+++ b/manifests/web/params.pp
@@ -13,14 +13,23 @@ class graylog2::web::params {
   # OS specific settings.
   case $::osfamily {
     'Debian', 'RedHat': {
-      # Nothing yet.
+      $package_name = 'graylog-web'
+      $config_file = '/etc/graylog/web/web.conf'
+      $bin_file = '/usr/share/graylog-web-interface/bin/graylog-web-interface'
+    }
+    'Gentoo': {
+      $package_name = 'app-admin/graylog-web-interface'
+      $config_file = '/etc/graylog/graylog-web-interface.conf'
+      $bin_file = '/opt/graylog-web-interface/bin/graylog-web-interface'
     }
     default: {
       fail("${::osfamily} is not supported by ${module_name}")
     }
   }
 
-  $package_name = 'graylog-web'
+  $log_file = '/var/log/graylog/graylog-web.log'
+
+  $pid_file = '/run/graylog/graylog-web.pid'
 
   $package_version = 'installed'
 
@@ -48,8 +57,6 @@ class graylog2::web::params {
 
   $extra_args = ''
   $java_opts = ''
-
-  $config_file = '/etc/graylog/web/web.conf'
 
   $daemon_username = 'graylog-web'
 

--- a/manifests/web/service.pp
+++ b/manifests/web/service.pp
@@ -16,6 +16,7 @@ class graylog2::web::service (
 
   $service_provider = $::operatingsystem ? {
     'Ubuntu' => 'upstart',
+    'Gentoo' => 'openrc',
     default  => undef,
   }
 

--- a/templates/server.gentoo.defaults.erb
+++ b/templates/server.gentoo.defaults.erb
@@ -1,0 +1,20 @@
+# WARNING: Maintained by Puppet. Manual changes will be lost!
+
+# Graylog Config:
+GRAYLOG_CONF="<%= @config_file %>"
+
+# Graylog Log:
+GRAYLOG_LOG="<%= @log_file %>"
+
+# Graylog PID:
+GRAYLOG_PID="<%= @pid_file %>"
+
+# Graylog Home:
+GRAYLOG_HOME="<%= @graylog_home_dir %>"
+
+# Default Java options for heap and garbage collection.
+DEFAULT_JAVA_OPTS="<%= @java_opts %>"
+
+# Program that will be used to wrap the graylog-server command. Useful to
+# support programs like authbind.
+GRAYLOG_COMMAND_WRAPPER="<%= @command_wrapper %>"

--- a/templates/web.gentoo.default.erb
+++ b/templates/web.gentoo.default.erb
@@ -1,0 +1,13 @@
+# WARNING: Maintained by Puppet. Manual changes will be lost!
+
+# Graylog Web Logfile:
+GRAYLOG_WEB_LOG="<%= @log_file %>"
+
+# Graylog Web PID:
+GRAYLOG_WEB_PID="<%= @pid_file %>"
+
+# Graylog Web Binary:
+GRAYLOG_WEB_BIN="<%= @bin_file %>"
+
+# Java options
+JAVAOPTS="<%= @java_opts %>"


### PR DESCRIPTION
I've added Gentoo Support, assuming the packages are found with the package names "app-admin/graylog-server" and "app-admin/graylog-web-interface" as stated in the ebuilds located at https://github.com/derdanne/gentoo-graylog.

I only added basic support for graylog-radio - i think the usage ist deprecated, or am i wrong?!