### PR TITLE
Fixing issue with array of zen unicasts hosts being added to the config file wrong

### DIFF
--- a/templates/server.conf.erb
+++ b/templates/server.conf.erb
@@ -192,7 +192,7 @@ elasticsearch_http_enabled = <%= @elasticsearch_http_enabled %>
 
 elasticsearch_discovery_zen_ping_multicast_enabled = <%= @elasticsearch_discovery_zen_ping_multicast_enabled %>
 <% if @elasticsearch_discovery_zen_ping_unicast_hosts %>
-elasticsearch_discovery_zen_ping_unicast_hosts = <%= @elasticsearch_discovery_zen_ping_unicast_hosts %>
+elasticsearch_discovery_zen_ping_unicast_hosts = <%= @elasticsearch_discovery_zen_ping_unicast_hosts.join(',') %>
 <% else %>
 #elasticsearch_discovery_zen_ping_unicast_hosts = 192.168.1.203:9300
 <% end %>


### PR DESCRIPTION
Fixing a problem where when entering an array of zen unicast hosts it would add them to the server.conf like 
`elasticsearch_discovery_zen_ping_unicast_hosts = ["host1:9300","host2:9300"]` 

Now it will join the array elements to save it properly in the format

`elasticsearch_discovery_zen_ping_unicast_hosts = host1:9300,host2:9300`