### PR TITLE
puppetlabs-apt 2.0 support

### DIFF
--- a/manifests/repo/debian.pp
+++ b/manifests/repo/debian.pp
@@ -26,10 +26,11 @@ class graylog2::repo::debian (
       release           => $release,
       repos             => $repos,
       pin               => $pin,
-      include_src       => false,
-      required_packages => ['apt-transport-https'],
+      include           => { 'src' => false },
       require           => File['/etc/apt/trusted.gpg.d/graylog2-keyring.gpg']
     }
+
+    Package['apt-transport-https'] -> Apt::Source[$repo_name]
 
     file {'/etc/apt/trusted.gpg.d/graylog2-keyring.gpg':
       ensure => present,

--- a/metadata.json
+++ b/metadata.json
@@ -39,7 +39,7 @@
     },
     {
       "name": "puppetlabs/apt",
-      "version_requirement": ">= 1.0.0 < 2.0.0"
+      "version_requirement": ">= 2.0.0"
     }
   ]
 }


### PR DESCRIPTION
Minor changes to add apt 2.0 module support.
The required_packages param does not exists anymore in apt 2.0, we ensure that apt-transport-https package is present before the apt::source using resource ordering.